### PR TITLE
Queue mode deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ In addition, we need to create _manually_ the database and user (and its passwor
 ### TL;DR
 
 After updating the `yaml` files with the right values
-```
-docker-compose -f docker-compose-pg-minikube.yml up -d # to start sftp and kafke if necessary in the same minikube network
+```sh
+$ docker-compose -f docker-compose-pg-minikube.yml up -d # to start sftp and kafke if necessary in the same minikube network
 
-helm install postgresn8n cetic/postgresql -f chart/pg-values.yaml # postgres backend for n8n in minikube
+$ helm install postgresn8n cetic/postgresql -f chart/pg-values.yaml # postgres backend for n8n in minikube
 
-kubectl port-forward --namespace default svc/postgresn8n-postgresql 15432:5432 &
+$ kubectl port-forward --namespace default svc/postgresn8n-postgresql 15432:5432 &
 
 psql --host 127.0.0.1 -p 15432 -U postgres -d postgres
 postgres@127:postgres> create user n8n with password 'n8np0stgr3s';
@@ -48,9 +48,9 @@ GRANT
 postgres@127:n8ndb> \q
 Goodbye!
 
-helm install n8n-poc oci://8gears.container-registry.com/library/n8n --version 0.20.1 -f chart/n8n-values.yaml
+$ helm install n8n-poc oci://8gears.container-registry.com/library/n8n --version 0.20.1 -f chart/n8n-values.yaml
 
-kubectl port-forward --namespace default svc/n8n-poc 8888:80 &
+$ kubectl port-forward --namespace default svc/n8n-poc 8888:80 &
 
 # connect to n8n as http://localhost:8888
 ```
@@ -84,12 +84,13 @@ As in the case of the postgresql deployment, we need to **forward the port** fro
 
 Install a redis instance using a helm chart
 
-```
+```sh
 $ helm install n8nredis oci://registry-1.docker.io/bitnamicharts/redis
 ```
 
 Then, follow the instructions printed after emitting the previous command. In short
-```
+
+```sh
 # get the password for redis
 $ kubectl get secret --namespace default n8nredis -o jsonpath="{.data.redis-password}" | base64 -d
 $ export REDIS_PASSWORD=$(kubectl get secret --namespace default n8nredis -o jsonpath="{.data.redis-password}" | base64 -d)
@@ -117,14 +118,14 @@ kubectl port-forward --namespace default svc/n8n-poc 8888:80 &
 
 #### Main instance autoscaling
 After deploying redis in the cluster, just update the `values.yaml` file to allow n8n work in [queue mode](https://docs.n8n.io/hosting/scaling/queue-mode/):
-- set `scaling.enabled` to true
+- set `.Values.autoscaling.enabled` to true
 - choose the number of workers to be spawned in the cluster
 - configure redis host parameters to be n8n able to communicate with it
 
-> This configuration will _autoscale_ the main instances but **not** the workers which is a bit counterintuitive as with high load you will see many main instances spawning but the workers keeps in a stable number. This might not be the desired behaviour.
+> This configuration will _autoscale_ the main instance but **not** the workers which is a bit counterintuitive as with high load you will see many main instances spawning but the workers keeps in a stable number. This might not be the desired behaviour.
 
 #### Worker instances autoscaling
-As it is the workers [who run the workflows](https://docs.n8n.io/hosting/scaling/queue-mode/#how-it-works) (but for those triggered [manually](https://docs.n8n.io/hosting/scaling/queue-mode/#running-n8n-with-queues)), it can be considered to be the workers which should be autoscaled. In order to do this one:
+As it is the workers [who run the workflows](https://docs.n8n.io/hosting/scaling/queue-mode/#how-it-works) (but those triggered [manually](https://docs.n8n.io/hosting/scaling/queue-mode/#running-n8n-with-queues) are still run by the main instance), it can be considered to be the workers which _should really be autoscaled_. In order to do this one:
 - to keep just one main instance, let's set `.Values.autoscaling.enabled` to `false`
 - add a new configuration to your _values_ file just like
 ```yaml
@@ -137,25 +138,25 @@ workerResources:
     memory: 256Mi
 ```
 - deploy n8n as described [above](#n8n-limited-high-availability)
-- then, deploy the `hpa-workder.yaml` (`kubectl apply -f hpa-worker.yaml`). You might need to update the `.spec.metrics` properties to adapt to your cluster and your needs
+- then, _apply_ `hpa-workder.yaml` (`kubectl apply -f hpa-worker.yaml`). You might need to update the `.spec.metrics` properties in the `hpa-worker.yaml` file to adapt to your cluster and your needs
 
 With this deployment, there will be _always_ just one main n8n instance and, depending on the workload, multiple workers will be spawned and removed automatically to adapt resources to the needs.
 
 We've observed that is necessary to explicitly define resource limits for both main and worker instances to be able to send metrics to the cluster's `metrics-server`. Otherwise, the metrics server won't get metrics and _horizontal pod autoscaler (HPA)_ won't be able to autoscale resources depending on workloads.
 
-The values for the `.Values.resources` and `.Values.workerResources` might be some tweak as well to adapt to the particular cluster.
+The values for the `.Values.resources` and `.Values.workerResources` might need some tweak as well to adapt to the particular cluster.
 
 ##### Workload testing
 
-Using the above configuration with workers autoscaling (max to 8) and verbosity of n8n main and workers instances to _info_ (it might slow the workflow processing), a performance/workload test was carried out:
-- macos sonora 2 GHz Quad-Core Intel Core i5 and 16Gb RAM
+Using the above configuration with workers autoscaling (max to 8 pods) and verbosity of n8n main and workers instances to _info_ (it might slow the workflow processing), a performance/workload test was carried out:
+- macos sonoma 14.3, 2 GHz Quad-Core Intel Core i5 and 16Gb RAM
 - minikube cluster with postgresql, redis and n8n in queue mode worker autoscaling deployed
-- two **simultaneous** message producers written in python, sending 11K and 10K messages with maximun delay of 0.2 and 0.3 seconds each (from terminal)
+- two **simultaneous** message producers written in python, publishing 11K and 10K messages with maximum delay of 0.2 and 0.3 seconds each (from terminal)
 - message broker was the same redis instance used by n8n to support queue mode
 - the [processing workflow](https://github.com/telekosmos/n8n-poc/blob/main/workflows/redis2s3%20-%20user%20behaviour%20events.json) is a simple workflow to pick the message, do some simple transformations on messages and send them to S3.
 
-Overall, performance was sufficient to good. All messages where picked up by the n8n autoscaling instance and sending in real time to S3, with no substantial delay observed.
+Overall, performance was sufficient to good. All messages where picked up by the n8n autoscaling instance and sent in real time to S3, with no substantial delay observed.
 
-While processing the messages the n8n designer got a bit responsive, so in a production environment the deployment should be devoted only to run workflows and leaving the development (and ideally staging) instances for workflow development.
+While processing the messages the n8n designer got a bit unresponsive, so in a production environment the deployment should be devoted only to run workflows and leaving the development (and ideally staging) instances for workflow development.
 
 All of the workers were over the top on max memory resource used (they went red in `k9s`). As mentioned, a more custom tweak based on trials might be necessary.

--- a/chart/n8n-values-scaling.yaml
+++ b/chart/n8n-values-scaling.yaml
@@ -1,0 +1,72 @@
+# values.yaml
+
+n8n:
+  encryption_key: my-secret-encryption-key
+  
+extraEnv:
+  N8N_LOG_LEVEL: info
+
+config:
+  database:
+    type: postgresdb
+    postgresdb:
+      database: n8ndb
+      # host: 10.97.45.104
+      host: postgresn8n-postgresql
+      user: n8n
+      password: '<n8n-user-password>'
+
+secret:
+  database:
+    postgresdb:
+      password: '<n8n-user-password>'
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+workerResources:
+  limits:
+    cpu: 1000m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+    
+replicaCount: 1
+# autoscaling:
+#   enabled: true
+#   minReplicas: 1
+#   maxReplicas: 6
+#   targetCPUUtilizationPercentage: 80
+
+# no autoscaling for workers!!! -> need to do a PR to update hpa to autoscale workers???
+scaling:
+  enabled: true
+
+  worker:
+    count: 2
+    concurrency: 2
+  # With .Values.scaling.webhook.enabled=true you disable Webhooks from the main process but you enable the processing on a different Webhook instance.
+  # See https://github.com/8gears/n8n-helm-chart/issues/39#issuecomment-1579991754 for the full explanation.
+  webhook:
+    enabled: false
+    count: 1
+
+  redis:
+    host: n8nredis-master.default.svc.cluster.local
+    password: <n8nredis-master.default.svc.cluster.local-password>

--- a/chart/n8n-values.yaml
+++ b/chart/n8n-values.yaml
@@ -1,5 +1,7 @@
 # values.yaml
-
+n8n:
+  encryption_key: my-secret-encryption-key
+  
 config:
   database:
     type: postgresdb
@@ -13,3 +15,19 @@ secret:
   database:
     postgresdb:
       password: '<password-for-n8n-user>'
+
+scaling:
+  enabled: true
+
+  worker:
+    count: 2
+    concurrency: 2
+  # With .Values.scaling.webhook.enabled=true you disable Webhooks from the main process but you enable the processing on a different Webhook instance.
+  # See https://github.com/8gears/n8n-helm-chart/issues/39#issuecomment-1579991754 for the full explanation.
+  webhook:
+    enabled: false
+    count: 1
+
+  redis:
+    host: <your-redis-host>
+    password: <password-for-redis-host>

--- a/hpa-worker.yaml
+++ b/hpa-worker.yaml
@@ -1,0 +1,29 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  annotations:
+    meta.helm.sh/release-name: n8n-poc-worker
+    meta.helm.sh/release-namespace: default
+  labels:
+    app.kubernetes.io/instance: n8n-poc-worker
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: n8n
+    app.kubernetes.io/version: 1.22.3
+    helm.sh/chart: n8n-0.20.1
+  name: n8n-poc-worker
+  namespace: default
+spec:
+  maxReplicas: 8
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 70
+        type: Utilization
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: n8n-poc-worker
+


### PR DESCRIPTION
Deployments and tests for the [_queue mode_](https://docs.n8n.io/hosting/scaling/queue-mode) operation mode.

Deployments in docker-compose and k8s using the excellent chart from [8gears](https://artifacthub.io/packages/helm/open-8gears/n8n) with our own values.

Come up with values and documentation to autoscale workers (which is not provided by the chart).

Also using a postgresql as a backend, remotely as a service and also deployed in the cluster or as a service in docker compose.

Local tests (run in a laptop machine) to evaluate the delay and the workload the platform can support and bear with.